### PR TITLE
Fix transparent urlbar with ATBC

### DIFF
--- a/toolbar/urlbar.css
+++ b/toolbar/urlbar.css
@@ -64,7 +64,7 @@
 
 #urlbar #urlbar-input {text-align: center !important}
 #urlbar-background {background: transparent !important;}
-#urlbar[focused="true"] > #urlbar-background {background: var(--toolbar-bgcolor) !important;}
+#urlbar[focused="true"] > #urlbar-background {background: var(--arrowpanel-background) !important;}
 
 /* URL bar suggestions container. */
 .urlbarView {

--- a/toolbar/urlbar.css
+++ b/toolbar/urlbar.css
@@ -73,7 +73,7 @@
   width: 100% !important;
   border-inline: 0 !important;
   padding-block: 0 !important;
-  background: var(--toolbar-bgcolor) !important;
+  background: var(--arrowpanel-background) !important;
   border-radius: 0 0 8px 8px !important;
 
 


### PR DESCRIPTION
fixes #16 

Fixes issue of URLbar sometimes being transparent.

If you are using ATBC extension to have different theme for each website and you also use popup URLbar, then you might need this fix.

This just sets the colors, but it might not match with link suggestion box's background (I'm talking about whats under URLbar).
You would also need to set this settings in extension preferences, here is mine: 

![image](https://github.com/KiKaraage/ArcWTF/assets/12684017/59266647-537e-4bee-9075-a226a0796a8a)

### Notice that Toolbar background setting is 1 tick higher than tab bar setting.


![image](https://github.com/KiKaraage/ArcWTF/assets/12684017/1832b262-0984-45dc-a91d-282de498db10)


Tested on FR 123.0.1
