### PR TITLE
Increasing sidebar hover zone area

### DIFF
--- a/tweaks/sidebar.css
+++ b/tweaks/sidebar.css
@@ -33,6 +33,16 @@
   opacity: 1%;
 }
 
+/* Add a pseudoelement to increase the hover area for the sidebar */
+
+#sidebar-box::before {
+  content: '';
+  position: absolute;
+  width: 25px;
+  height: 100%;
+  z-index:-1;
+}
+
 /* if this preference is activated in about:config, sidebar width will be increased */
 @media (-moz-bool-pref: "uc.tweak.longer-sidebar") {
   :root #sidebar-box {

--- a/tweaks/sidebar.css
+++ b/tweaks/sidebar.css
@@ -38,7 +38,7 @@
 #sidebar-box::before {
   content: '';
   position: absolute;
-  width: 25px;
+  width: 16px;
   height: 100%;
   z-index:-1;
 }


### PR DESCRIPTION
Fix for #28: Bigger hover zone for the sidebar.

Adding a pseudoelement to the `#sidebar-box` element on _sidebar.css_ to increase the width of the default hover zone.

![Behavior of the extended hoverable area](https://github.com/KiKaraage/ArcWTF/assets/10903395/34b8262c-280c-4d51-a3c1-66830ca59025)

The 25px width hoverable area on line 41 works for me but, since it's slightly bigger than the border, I recommend testing the behavior on different screen resolutions.

---

Tested on Firefox 125.0.2 running on Linux