### PR TITLE
fix urlbar popup when an IME is invoked

### DIFF
--- a/toolbar/urlbar.css
+++ b/toolbar/urlbar.css
@@ -46,7 +46,7 @@
   }
 
   /* Appearance when the URL bar is expanded. */
-  #urlbar:is([open], [usertyping][focused="true"]) & {
+  #urlbar:is([open], [usertyping][focused]) & {
     border-radius: 8px !important;
     border-color: transparent !important;
     outline: 0px solid var(--arrowpanel-border-color) !important;
@@ -65,7 +65,7 @@
 
 #urlbar #urlbar-input {text-align: center !important}
 #urlbar-background {background: transparent !important;}
-#urlbar[focused="true"] > #urlbar-background {background: var(--arrowpanel-background) !important;}
+#urlbar[focused] > #urlbar-background {background: var(--arrowpanel-background) !important;}
 
 /* URL bar suggestions container. */
 .urlbarView {

--- a/toolbar/urlbar.css
+++ b/toolbar/urlbar.css
@@ -11,6 +11,7 @@
   --identity-box-margin-inline: 6px !important;
   --uc-urlbar-icon-inline-padding: calc(var(--uc-toolbarbutton-inner-inline-padding));
   --uc-urlbar-inline-padding: 6px;
+  --uc-urlbar-block-padding: 6px;
   --uc-urlbar-shadow: 0 0 0px rgb(0 0 0 / .1);
    --urlbarView-rich-suggestion-default-icon-size: 32px !important;
 
@@ -45,7 +46,7 @@
   }
 
   /* Appearance when the URL bar is expanded. */
-  #urlbar[open] & {
+  #urlbar:is([open], [usertyping][focused="true"]) & {
     border-radius: 8px !important;
     border-color: transparent !important;
     outline: 0px solid var(--arrowpanel-border-color) !important;

--- a/tweaks/popup-search.css
+++ b/tweaks/popup-search.css
@@ -1,6 +1,6 @@
 /* search */
 @media (-moz-bool-pref: "uc.tweak.popup-search") {
-  #urlbar:is([breakout][breakout-extend], [breakout][usertyping][focused="true"]) {
+  #urlbar:is([breakout][breakout-extend], [breakout][usertyping][focused]) {
     #urlbar-input {
       font-size: 16px !important;
       text-align: left !important;
@@ -36,7 +36,7 @@
   }
 
   /* background */
-  #nav-bar:has(#urlbar:is([breakout][breakout-extend], [breakout][usertyping][focused="true"])){
+  #nav-bar:has(#urlbar:is([breakout][breakout-extend], [breakout][usertyping][focused])){
     /* created as :after so that elements to the right of 
        urlbar will be covered properly */
     &:after {

--- a/tweaks/popup-search.css
+++ b/tweaks/popup-search.css
@@ -1,47 +1,58 @@
 /* search */
 @media (-moz-bool-pref: "uc.tweak.popup-search") {
-#urlbar:is([breakout][breakout-extend]){
-  #urlbar-input {
-    font-size: 16px !important;
-    text-align: left !important;
-    padding-block: 12px !important;
-   padding-inline: 3px !important;
-  }
-  
-  position: fixed !important;
-  padding-top: 12px !important;
-  --urlbar-height: auto !important;
-  bottom: auto !important;
-  top: 20vh !important;
-  padding-left: 6px !important;
-  padding-right: 8px !important;
-  background-color: #toolbar-bgcolor !important;
-  
-  left: 18vw !important;
-  right: 18vw !important;
-  width: 64vw !important;
-  
-  & .urlbarView-results {
-    margin-top: 12px !important;
-    padding-block-start: 0px !important;
+  #urlbar:is([breakout][breakout-extend], [breakout][usertyping][focused="true"]) {
+    #urlbar-input {
+      font-size: 16px !important;
+      text-align: left !important;
+    }
+    #urlbar-input-container {
+      height: auto !important;
+      padding-block: var(--urlbar-block-padding) !important;
+      padding-inline: var(--urlbar-inline-padding) !important;
+    }
+    #urlbar-go-button {
+      margin: auto !important;
+    }
+    
+    z-index: 1;
+    position: fixed !important;
+    padding-block: 12px!important;
+    --urlbar-height: auto !important;
+    bottom: auto !important;
+    top: 20vh !important;
+    padding-left: 6px !important;
+    padding-right: 8px !important;
+    background-color: #toolbar-bgcolor !important;
+    
+    left: 18vw !important;
+    right: 18vw !important;
+    width: 64vw !important;
+    
+    & .urlbarView-results {
+      margin-top: 12px !important;
+      padding-block-start: 0px !important;
+    }    
+
   }
 
-  
   /* background */
-  &:before{
-    content: "";
-    position: fixed;
-    pointer-events: none;
-    
-    width: 100vw;
-    height: 100vh;
-    
-    top: 0px;
-    left: 0px;
-    
-    background-color: #000000;
-    opacity: 0.5;
-    backdrop-filter: blur(300px);
+  #nav-bar:has(#urlbar:is([breakout][breakout-extend], [breakout][usertyping][focused="true"])){
+    /* created as :after so that elements to the right of 
+       urlbar will be covered properly */
+    &:after {
+      content: "";
+      position: fixed;
+      pointer-events: none;
+      
+      width: 100vw;
+      height: 100vh;
+      
+      top: 0px;
+      left: 0px;
+      
+      background-color: #000000; !important;
+      opacity: 0.5;
+      backdrop-filter: blur(300px);
+    }
   }
-}
 }


### PR DESCRIPTION
Fix an issue where when Input Method Editors are invoked, the popup urlbar is dismissed due to `breakout-extend` attribute no longer being available. 

The code changes include:
- Update the condition for urlbar popup from `breakout-extend` to `usertyping` and `focused="true"`. Note that relying on only `usertyping` will cause the urlbar to remain in place even when a mouse click is sent.
- Fixate padding on various places to accommodate height difference between Latin and CJK characters.
- Move popup urlbar shadow to `#nav-bar::after`, so that elements to the right of urlbar are properly covered.

https://github.com/KiKaraage/ArcWTF/assets/7515838/17662fbe-74f9-4be7-9ed0-1a40285d0be1

https://github.com/KiKaraage/ArcWTF/assets/7515838/43d0b63e-ef67-4fda-abbf-fe5dd492b2ab


---
Tested on Firefox 127.0 (64-bit) on Windows 11 22635.3785