### PR TITLE
fix: transparent url background

### DIFF
--- a/toolbar/urlbar.css
+++ b/toolbar/urlbar.css
@@ -64,7 +64,7 @@
 
 #urlbar #urlbar-input {text-align: center !important}
 #urlbar-background {background: transparent !important;}
-#urlbar[focused=""] > #urlbar-background {background: var(--arrowpanel-background) !important;}
+#urlbar[focused] > #urlbar-background {background: var(--arrowpanel-background) !important;}
 
 /* URL bar suggestions container. */
 .urlbarView {

--- a/toolbar/urlbar.css
+++ b/toolbar/urlbar.css
@@ -64,7 +64,7 @@
 
 #urlbar #urlbar-input {text-align: center !important}
 #urlbar-background {background: transparent !important;}
-#urlbar[focused="true"] > #urlbar-background {background: var(--arrowpanel-background) !important;}
+#urlbar[focused=""] > #urlbar-background {background: var(--arrowpanel-background) !important;}
 
 /* URL bar suggestions container. */
 .urlbarView {


### PR DESCRIPTION
Due to changes in firefox (im on version 128.0b3 dev edition) the focused attribute in the newer firefox version isnt "true" but just ""

This pr can sit here till the normal firefox gets the change