### PR TITLE
Firefox 128 update

### DIFF
--- a/global/browser.css
+++ b/global/browser.css
@@ -111,6 +111,11 @@
     }
   }
 
+  /* Apply rounded corners to the browser content. */
+  #appcontent .browserStack browser {
+    border-radius: var(--uc-tweak-rounded-corners-radius) !important;
+  }
+
   /* Prevent status panel corners and shadow from appearing outside the browser. */
   #statuspanel {
     overflow: hidden;

--- a/global/colors.css
+++ b/global/colors.css
@@ -3,13 +3,14 @@
 
 /* default colours (light & dark) */
 :root:not(:-moz-lwtheme),
+:root:not([lwtheme]),
 /* `--newtab-background-color-secondary used` to differentiate between a dark
  * private window and private window with the 'Dark' theme enabled.
  * May not be the most reliable method, but works for now up to FF 123. */
 :root[privatebrowsingmode="temporary"]:where([style*="--lwt-accent-color: rgb(28, 27, 34)"]:not([style*="--newtab-background-color-secondary: rgb(66, 65, 77)"])) {
   /* Toolbars */
-  --lwt-accent-color: light-dark(#cecece, #1C1C1C) !important;
-  --lwt-accent-color-inactive: light-dark(#e8e8e8, #2e2e2e) !important;
+  --lwt-accent-color: light-dark(rgb(240, 240, 244), rgb(28, 27, 34)) !important;
+  --lwt-accent-color-inactive: light-dark(rgb(235, 235, 239), rgb(31, 30, 37)) !important;
   --lwt-text-color: light-dark(#000, #FFF) !important;
   --lwt-text-color-inactive: light-dark(#3A3A3A, #CBCBCB) !important;
   --tab-selected-textcolor: light-dark(#000, #fff) !important;

--- a/toolbar/urlbar.css
+++ b/toolbar/urlbar.css
@@ -64,7 +64,8 @@
 
 #urlbar #urlbar-input {text-align: center !important}
 #urlbar-background {background: transparent !important;}
-#urlbar[focused="true"] > #urlbar-background {background: var(--arrowpanel-background) !important;}
+#nav-bar[urlbar-exceeds-toolbar-bounds="true"] #urlbar-background {background: var(--arrowpanel-background) !important;}
+/* #urlbar[focused=""] > #urlbar-background {background: var(--arrowpanel-background) !important;} */
 
 /* URL bar suggestions container. */
 .urlbarView {

--- a/tweaks/sidebar.css
+++ b/tweaks/sidebar.css
@@ -111,7 +111,39 @@
   min-width: var(--uc-sidebar-hover-width) !important;
   transition-delay: 0ms !important;
   opacity: 100% !important;
+  border-radius: 0 !important;
 }
+
+/* Show bottom right rounded corner when hovering sidebar */
+#sidebar-box:hover::before {
+  content: "";
+  position: absolute;
+  background-color: transparent;
+
+  bottom: 10px;
+  left: var(--uc-sidebar-hover-width);
+
+  height: 15px;
+  width: 65px;
+  border-bottom-left-radius: var(--uc-tweak-rounded-corners-radius);
+  box-shadow: -5px 0 0 0 var(--lwt-accent-color);
+}
+
+/* Show top right rounded corner when hovering sidebar */
+#sidebar-box:hover::after {
+  content: "";
+  position: absolute;
+  background-color: transparent;
+
+  top: 0px;
+  left: var(--uc-sidebar-hover-width);
+
+  height: 15px;
+  width: 65px;
+  border-top-left-radius: var(--uc-tweak-rounded-corners-radius);
+  box-shadow: -5px 0 0 0 var(--lwt-accent-color);
+}
+
 #sidebar-box:hover {
   opacity: 100% !important;
 }


### PR DESCRIPTION
Show rounded corners on browser content (Windows)
Show rounded corners on sidebar hover
Searchbar popup transparent input fixed
Sidebar title transparent background fixed


Tested on Windows 11, Firefox 128.0