### PR TITLE
Fix vertical height of scroll box

### DIFF
--- a/sidebery-css-style
+++ b/sidebery-css-style
@@ -64,8 +64,7 @@
   font-size: 0.85rem;
 }
 
-body,
-.ScrollBox {
+body {
   height: 100vh;
   overflow: hidden;
 }


### PR DESCRIPTION
The box dialog that shows up when right clicking a tab had 100vh height, I'm attaching the before and after images:

Before:
<img width="191" alt="before" src="https://github.com/user-attachments/assets/1ce8ffdc-96b5-462d-a5af-f5666c923dcd">
After:
<img width="194" alt="after" src="https://github.com/user-attachments/assets/502d0734-f41d-47fa-9301-adaa227cb19e">
