### PR TITLE
Hide New Tab Icon Badge

### DIFF
--- a/sidebery-css-style
+++ b/sidebery-css-style
@@ -140,6 +140,12 @@ body {
   mask: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjxzdmcgZmlsbD0ibm9uZSIgaGVpZ2h0PSIyMCIgdmlld0JveD0iMCAwIDIwIDIwIiB3aWR0aD0iMjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTTEwIDIuNUMxMCAyLjIyMzg2IDkuNzc2MTQgMiA5LjUgMkM5LjIyMzg2IDIgOSAyLjIyMzg2IDkgMi41VjlIMi41QzIuMjIzODYgOSAyIDkuMjIzODYgMiA5LjVDMiA5Ljc3NjE0IDIuMjIzODYgMTAgMi41IDEwSDlWMTYuNUM5IDE2Ljc3NjEgOS4yMjM4NiAxNyA5LjUgMTdDOS43NzYxNCAxNyAxMCAxNi43NzYxIDEwIDE2LjVWMTBIMTYuNUMxNi43NzYxIDEwIDE3IDkuNzc2MTQgMTcgOS41QzE3IDkuMjIzODYgMTYuNzc2MSA5IDE2LjUgOUgxMFYyLjVaIiBmaWxsPSIjMjEyMTIxIi8+PC9zdmc+");
 }
 
+.TabsPanel .new-tab-btn:first-of-type > svg.-badge,
+.TabsPanel .new-tab-btn:first-of-type > img.-badge {
+	width: 0;
+	height: 0;
+}
+
 .TabsPanel .new-tab-btn:first-of-type:after {
   justify-content: left;
   content: "New Tab";


### PR DESCRIPTION
Adding svg/img badge new tab + selector to hide it

```
.TabsPanel .new-tab-btn:first-of-type > svg.-badge,
.TabsPanel .new-tab-btn:first-of-type > img.-badge
```
before
![image](https://github.com/user-attachments/assets/92d1bf10-3be1-42f0-84d9-e923cf0203ef)
after
![image](https://github.com/user-attachments/assets/2665d769-553c-4f5a-b1a9-37ee99749afe)
