### PR TITLE
fix: appcontent renamed

### DIFF
--- a/global/browser.css
+++ b/global/browser.css
@@ -84,7 +84,7 @@
   }
   
   /* Apply rounded corners to the browser container. */
-  #appcontent .browserStack {
+  #tabbrowser-tabbox .browserStack {
     margin-inline-start: var(--uc-tweak-rounded-corners-padding) !important;
     margin-inline-end: var(--uc-tweak-rounded-corners-padding) !important;
     margin-block-start: 0px !important;
@@ -112,7 +112,7 @@
   }
 
   /* Apply rounded corners to the browser content. */
-  #appcontent .browserStack browser {
+  #tabbrowser-tabbox .browserStack browser {
     border-radius: var(--uc-tweak-rounded-corners-radius) !important;
   }
 
@@ -159,7 +159,7 @@
     border-inline-width: 0 !important;
   }
 
-  :root[sizemode="normal"] #appcontent .browserStack) {
+  :root[sizemode="normal"] #tabbrowser-tabbox .browserStack) {
     margin-inline-end: 25px !important;
     margin-block-end: 25px !important;
 }

--- a/tweaks/mac-translucent.css
+++ b/tweaks/mac-translucent.css
@@ -91,9 +91,9 @@
   }
 }
 
-#appcontent .browserStack { overflow: hidden !important; padding-left: 0 !important; margin-left: 0 !important; }
+#tabbrowser-tabbox .browserStack { overflow: hidden !important; padding-left: 0 !important; margin-left: 0 !important; }
 
-#appcontent { background-color: var(--sidebery-bg-color) !important;    }
+#tabbrowser-tabbox { background-color: var(--sidebery-bg-color) !important;    }
 
 /*Sidebar Expanded*/
 #sidebar-box, #sidebar {

--- a/tweaks/sidebar.css
+++ b/tweaks/sidebar.css
@@ -141,10 +141,10 @@
 
 /* Move statuspanel to the other side when sidebar is hovered so it doesn't get covered by sidebar */
 
-#sidebar-box:not([positionend]):hover ~ #appcontent #statuspanel {
+#sidebar-box:not([positionend]):hover ~ #tabbrowser-tabbox #statuspanel {
   inset-inline: auto 0px !important;
 }
-#sidebar-box:not([positionend]):hover ~ #appcontent #statuspanel-label {
+#sidebar-box:not([positionend]):hover ~ #tabbrowser-tabbox #statuspanel-label {
   margin-inline: 0px !important;
   border-left-style: solid !important;
 }
@@ -171,10 +171,10 @@
     margin-left: calc(var(--sdbr-real-wdt) * -1);
   }
 
-  & #browser > #appcontent {
+  & #browser > #tabbrowser-tabbox {
     margin-left: var(--sdbr-real-wdt);
   }
-  & #appcontent browser {
+  & #tabbrowser-tabbox browser {
     margin-left: 0px;
   }
   & #statuspanel {


### PR DESCRIPTION
`#appcontent` was renamed to `#tabbrowser-tabbox` in Firefox v132
closes #102 