### PR TITLE
fix: border on hidden sidebar

### DIFF
--- a/tweaks/hide-tabs-bar.css
+++ b/tweaks/hide-tabs-bar.css
@@ -157,20 +157,6 @@
     }
   }
 
-  /* Sidebar positioned on the left. */
-  &:not([positionend]) {
-    border-inline-end: 1px solid var(--sidebar-border-color);
-    /* Use less padding on the side with the border. */
-    padding-inline: 4px 3px;
-  }
-
-  /* Sidebar positioned on the right. */
-  &[positionend] {
-    border-inline-start: 1px solid var(--sidebar-border-color);
-    /* Use less padding on the side with the border. */
-    padding-inline: 3px 4px;
-  }
-
   /* Rounded corners tweak optimisations. */
   @media (-moz-bool-pref: "uc.tweak.rounded-corners") {
     /* Remove padding and border from sidebar. */

--- a/tweaks/sidebar.css
+++ b/tweaks/sidebar.css
@@ -149,6 +149,12 @@
   border-left-style: solid !important;
 }
 
+#main-window {
+  --uc-tweak-sidebar-margin-offset: calc(
+      var(--uc-tweak-rounded-corners-padding) - 3px
+    ) !important;
+}
+
 #main-window[titlepreface*="|| "] {
   --ovrl-wdt: var(--ovrl-max-wdt);
 
@@ -181,16 +187,9 @@
     margin-left: 2px;
   }
 
+  & #sidebar-header,
   & #sidebar {
-    margin-inline-start: calc(
-      var(--uc-tweak-rounded-corners-padding) - 3px
-    ) !important;
-  }
-
-  & #sidebar-header {
-    margin-inline-start: calc(
-      var(--uc-tweak-rounded-corners-padding) - 3px
-    ) !important;
+    margin-inline-start: var(--uc-tweak-sidebar-margin-offset)
   }
 
   & #sidebar-box:hover > #sidebar {
@@ -199,5 +198,39 @@
     ) !important;
     min-width: var(--uc-sidebar-hover-width) !important;
     transition-delay: 0ms !important;
+  }
+}
+
+#main-window:not([titlepreface*="|| "]) {
+  & #sidebar-box {
+    & #sidebar-header,
+    & #sidebar {
+      margin-inline-start: var(--uc-tweak-sidebar-margin-offset) !important;
+    }
+  }
+
+  & #sidebar-box[positionend] {
+    & #sidebar-header,
+    & #sidebar {
+      margin-inline-end: var(--uc-tweak-sidebar-margin-offset) !important;
+    }
+  }
+
+  & #sidebar-header,
+  & #sidebar {
+    padding-inline: 4px !important;
+    border: 1px solid var(--sidebar-border-color);
+  }
+
+  & #sidebar-header {
+    border-bottom: none;
+    border-top-left-radius: var(--uc-tweak-rounded-corners-radius) !important;
+    border-top-right-radius: var(--uc-tweak-rounded-corners-radius) !important;
+  }
+
+  & #sidebar {
+    border-top: none;
+    border-bottom-left-radius: var(--uc-tweak-rounded-corners-radius) !important;
+    border-bottom-right-radius: var(--uc-tweak-rounded-corners-radius) !important;
   }
 }


### PR DESCRIPTION
Improves border behavior for the hidden sidebar. Note the line in the bottom left of the "Before" frame

Developed on Firefox 133.0.3 with Sidebery.

![before_after](https://github.com/user-attachments/assets/dd69c759-c031-455c-a394-d500111af206)


