### PR TITLE
Fix margin issues

### DIFF
--- a/global/browser.css
+++ b/global/browser.css
@@ -43,7 +43,7 @@
 
   /* Variables used for the rounded corners. */
   #main-window:not([chromehidden~="toolbar"]) {
-    --uc-tweak-rounded-corners-padding: 10px;
+    --uc-tweak-rounded-corners-padding: 0px;
     --uc-tweak-rounded-corners-radius: 8px;
     --uc-tweak-rounded-corners-shadow:
       0 -.8px 0 0 rgb(0 0 0 / 0.02),


### PR DESCRIPTION
# Issue Description

At least on MacOS, Firefox 134.02 the whole content frame (ie sidebar + browser) is offseted.
See screenshot where i colored them .

I managed to fix it with this change but i'm not sure it's the proper one as i'm not familiar with Firefow elements.

Note my config:
- no titlebar
- no personal bar

<img width="1822" alt="Capture d’écran 2025-01-28 à 15 47 24" src="https://github.com/user-attachments/assets/db2b94de-706e-4894-a46b-b2887cb01c6b" />
<img width="1822" alt="Capture d’écran 2025-01-28 à 15 47 33" src="https://github.com/user-attachments/assets/63837bb0-221f-4109-85e3-5f888d34e81e" />
